### PR TITLE
Fix benchmarks and documentation generation

### DIFF
--- a/benches/bls12_381/ec.rs
+++ b/benches/bls12_381/ec.rs
@@ -2,7 +2,7 @@ mod g1 {
     use rand_core::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
-    use blstrs::*;
+    use blstrs_plus::*;
     use ff::Field;
     use group::Group;
 
@@ -87,7 +87,7 @@ mod g2 {
     use rand_core::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
-    use blstrs::*;
+    use blstrs_plus::*;
     use ff::Field;
     use group::Group;
 

--- a/benches/bls12_381/mod.rs
+++ b/benches/bls12_381/mod.rs
@@ -10,7 +10,7 @@ mod scalar;
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
-use blstrs::*;
+use blstrs_plus::*;
 use group::{Curve, Group};
 use pairing_lib::{Engine, MillerLoopResult, MultiMillerLoop};
 
@@ -148,7 +148,7 @@ fn bench_g1_multi_exp(b: &mut ::test::Bencher) {
     let points: Vec<G1Projective> = (0..SIZE).map(|_| G1Projective::random(&mut rng)).collect();
     let scalars: Vec<Scalar> = (0..SIZE).map(|_| Scalar::random(&mut rng)).collect();
 
-    b.iter(|| G1Projective::multi_exp(points.as_slice(), scalars.as_slice()));
+    b.iter(|| G1Projective::sum_of_products(points.as_slice(), scalars.as_slice()));
 }
 
 #[bench]
@@ -185,5 +185,5 @@ fn bench_g2_multi_exp(b: &mut ::test::Bencher) {
     let points: Vec<G2Projective> = (0..SIZE).map(|_| G2Projective::random(&mut rng)).collect();
     let scalars: Vec<Scalar> = (0..SIZE).map(|_| Scalar::random(&mut rng)).collect();
 
-    b.iter(|| G2Projective::multi_exp(points.as_slice(), scalars.as_slice()));
+    b.iter(|| G2Projective::sum_of_products(points.as_slice(), scalars.as_slice()));
 }

--- a/benches/bls12_381/scalar.rs
+++ b/benches/bls12_381/scalar.rs
@@ -1,7 +1,7 @@
 use rand_core::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
-use blstrs::*;
+use blstrs_plus::*;
 use ff::{Field, PrimeField};
 
 #[bench]

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -391,8 +391,7 @@ impl G1Affine {
             .and_then(|p| CtOption::new(p, p.is_on_curve() & p.is_torsion_free()))
     }
 
-    /// Attempts to deserialize a uncompressed element hex string. See [`notes::serialization`](crate::notes::serialization)
-    /// for details about how group elements are serialized.
+    /// Attempts to deserialize a uncompressed element hex string.
     pub fn from_uncompressed_hex(hex: &str) -> CtOption<Self> {
         let mut bytes = [0u8; UNCOMPRESSED_SIZE];
         util::decode_hex_into_slice(&mut bytes, hex.as_bytes());
@@ -417,8 +416,7 @@ impl G1Affine {
             .and_then(|p| CtOption::new(p, p.is_on_curve() & p.is_torsion_free()))
     }
 
-    /// Attempts to deserialize a compressed element hex string. See [`notes::serialization`](crate::notes::serialization)
-    /// for details about how group elements are serialized.
+    /// Attempts to deserialize a compressed element hex string.
     pub fn from_compressed_hex(hex: &str) -> CtOption<Self> {
         let mut bytes = [0u8; COMPRESSED_SIZE];
         util::decode_hex_into_slice(&mut bytes, hex.as_bytes());

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -420,8 +420,7 @@ impl G2Affine {
             .and_then(|p| CtOption::new(p, p.is_on_curve() & p.is_torsion_free()))
     }
 
-    /// Attempts to deserialize a uncompressed element hex string. See [`notes::serialization`](crate::notes::serialization)
-    /// for details about how group elements are serialized.
+    /// Attempts to deserialize a uncompressed element hex string.
     pub fn from_uncompressed_hex(hex: &str) -> CtOption<Self> {
         let mut bytes = [0u8; UNCOMPRESSED_SIZE];
         util::decode_hex_into_slice(&mut bytes, hex.as_bytes());
@@ -446,8 +445,7 @@ impl G2Affine {
             .and_then(|p| CtOption::new(p, p.is_on_curve() & p.is_torsion_free()))
     }
 
-    /// Attempts to deserialize a compressed element hex string. See [`notes::serialization`](crate::notes::serialization)
-    /// for details about how group elements are serialized.
+    /// Attempts to deserialize a compressed element hex string.
     pub fn from_compressed_hex(hex: &str) -> CtOption<Self> {
         let mut bytes = [0u8; COMPRESSED_SIZE];
         util::decode_hex_into_slice(&mut bytes, hex.as_bytes());


### PR DESCRIPTION
This removes the references to `notes::serialization`. That could be copied over from bls12_381, but then the katex headers would need to be added as well.